### PR TITLE
Refactor layout with Material UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "react-router-dom": "^6.22.3",
     "react-scripts": "^5.0.1",
     "redux-saga": "^1.2.3",
-    "sass": "^1.69.7"
+    "sass": "^1.69.7",
+    "@mui/material": "^5.15.8",
+    "@mui/icons-material": "^5.15.8",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0"
   },
   "browserslist": {
     "production": [

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,12 +1,15 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useMemo, useState } from 'react';
+import { ThemeProvider as MUIThemeProvider, createTheme } from '@mui/material/styles';
 
 export const ThemeContext = createContext();
 
 const ThemeProvider = ({ children }) => {
   const [dark, setDark] = useState(false);
+  const theme = useMemo(() => createTheme({ palette: { mode: dark ? 'dark' : 'light' } }), [dark]);
+  const toggle = () => setDark(d => !d);
   return (
-    <ThemeContext.Provider value={{ dark, toggle: () => setDark(d => !d) }}>
-      {children}
+    <ThemeContext.Provider value={{ dark, toggle }}>
+      <MUIThemeProvider theme={theme}>{children}</MUIThemeProvider>
     </ThemeContext.Provider>
   );
 };

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Outlet, Routes, Route, Navigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import CssBaseline from '@mui/material/CssBaseline';
 import Sidebar from './Sidebar';
 import Topbar from './Topbar';
 import Dashboard from '../pages/Dashboard';
@@ -9,25 +12,27 @@ import Referrals from '../pages/Referrals';
 import Settings from '../pages/Settings';
 import './Layout.scss';
 
+const drawerWidth = 240;
+
 const Layout = () => {
   return (
-    <div className="layout">
+    <Box sx={{ display: 'flex' }} className="layout">
+      <CssBaseline />
+      <Topbar />
       <Sidebar />
-      <div className="layout__content">
-        <Topbar />
-        <div className="layout__page">
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/users" element={<Users />} />
-            <Route path="/payments" element={<Payments />} />
-            <Route path="/referrals" element={<Referrals />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-          <Outlet />
-        </div>
-      </div>
-    </div>
+      <Box component="main" sx={{ flexGrow: 1, p: 3, width: `calc(100% - ${drawerWidth}px)` }}>
+        <Toolbar />
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/users" element={<Users />} />
+          <Route path="/payments" element={<Payments />} />
+          <Route path="/referrals" element={<Referrals />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+        <Outlet />
+      </Box>
+    </Box>
   );
 };
 

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,20 +1,50 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import PeopleIcon from '@mui/icons-material/People';
+import PaymentIcon from '@mui/icons-material/Payment';
+import ShareIcon from '@mui/icons-material/Share';
+import SettingsIcon from '@mui/icons-material/Settings';
 import './Sidebar.scss';
 
+const drawerWidth = 240;
+
+const navItems = [
+  { to: '/', label: 'Dashboard', icon: <DashboardIcon />, end: true },
+  { to: '/users', label: 'Users', icon: <PeopleIcon /> },
+  { to: '/payments', label: 'Payments', icon: <PaymentIcon /> },
+  { to: '/referrals', label: 'Referrals', icon: <ShareIcon /> },
+  { to: '/settings', label: 'Settings', icon: <SettingsIcon /> },
+];
+
 const Sidebar = () => (
-  <aside className="sidebar">
-    <h2 className="sidebar__title">Admin</h2>
-    <nav>
-      <ul>
-        <li><NavLink to="/" end>Dashboard</NavLink></li>
-        <li><NavLink to="/users">Users</NavLink></li>
-        <li><NavLink to="/payments">Payments</NavLink></li>
-        <li><NavLink to="/referrals">Referrals</NavLink></li>
-        <li><NavLink to="/settings">Settings</NavLink></li>
-      </ul>
-    </nav>
-  </aside>
+  <Drawer variant="permanent" sx={{ width: drawerWidth, [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' } }}>
+    <Toolbar>
+      <Typography variant="h6" noWrap component="div">
+        Admin
+      </Typography>
+    </Toolbar>
+    <List>
+      {navItems.map(({ to, label, icon, end }) => (
+        <ListItemButton
+          key={label}
+          component={NavLink}
+          to={to}
+          end={end}
+        >
+          <ListItemIcon>{icon}</ListItemIcon>
+          <ListItemText primary={label} />
+        </ListItemButton>
+      ))}
+    </List>
+  </Drawer>
 );
 
 export default Sidebar;

--- a/src/layouts/Topbar.jsx
+++ b/src/layouts/Topbar.jsx
@@ -1,17 +1,35 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useDispatch } from 'react-redux';
 import { logout } from '../redux/slices/authSlice';
-import './Topbar.scss';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import LogoutIcon from '@mui/icons-material/Logout';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+import { useTheme } from '@mui/material/styles';
+import { ThemeContext } from '../contexts/ThemeContext';
 
 const Topbar = () => {
   const dispatch = useDispatch();
+  const theme = useTheme();
+  const { dark, toggle } = useContext(ThemeContext);
+
   const handleLogout = () => {
     dispatch(logout());
   };
+
   return (
-    <header className="topbar">
-      <button onClick={handleLogout}>Logout</button>
-    </header>
+    <AppBar position="fixed" sx={{ zIndex: theme.zIndex.drawer + 1 }}>
+      <Toolbar sx={{ justifyContent: 'flex-end' }}>
+        <IconButton color="inherit" onClick={toggle} sx={{ mr: 2 }}>
+          {dark ? <Brightness7Icon /> : <Brightness4Icon />}
+        </IconButton>
+        <IconButton color="inherit" onClick={handleLogout} data-testid="logout">
+          <LogoutIcon />
+        </IconButton>
+      </Toolbar>
+    </AppBar>
   );
 };
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,5 +1,31 @@
 import React from 'react';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
 
-const Dashboard = () => <h1>Dashboard</h1>;
+const stats = [
+  { title: 'Users', value: 125 },
+  { title: 'Payments', value: '$5,300' },
+  { title: 'Referrals', value: 34 },
+];
+
+const Dashboard = () => (
+  <>
+    <Typography variant="h4" gutterBottom>Dashboard</Typography>
+    <Grid container spacing={2}>
+      {stats.map(({ title, value }) => (
+        <Grid item xs={12} md={4} key={title}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6">{title}</Typography>
+              <Typography variant="h4">{value}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  </>
+);
 
 export default Dashboard;

--- a/src/pages/Users.jsx
+++ b/src/pages/Users.jsx
@@ -1,5 +1,43 @@
 import React from 'react';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
 
-const Users = () => <h1>Users</h1>;
+const rows = [
+  { id: 1, name: 'Alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob', email: 'bob@example.com' },
+  { id: 3, name: 'Charlie', email: 'charlie@example.com' },
+];
+
+const Users = () => (
+  <>
+    <Typography variant="h4" gutterBottom>Users</Typography>
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Email</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map(row => (
+            <TableRow key={row.id} hover>
+              <TableCell>{row.id}</TableCell>
+              <TableCell>{row.name}</TableCell>
+              <TableCell>{row.email}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  </>
+);
 
 export default Users;


### PR DESCRIPTION
## Summary
- add MUI dependencies
- integrate MUI theme provider with dark/light toggle
- rebuild Sidebar using Drawer and icons
- rebuild Topbar using AppBar with logout and theme toggle
- update Layout for MUI layout structure
- convert Dashboard and Users pages to MUI components

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686417713bc4832b9ed8ca0868ff9f6d