### PR TITLE
Add blockchain and mnemonic pages

### DIFF
--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -10,6 +10,8 @@ import Users from '../pages/Users';
 import Payments from '../pages/Payments';
 import Referrals from '../pages/Referrals';
 import Settings from '../pages/Settings';
+import Mnemonics from '../pages/Mnemonics';
+import Blockchains from '../pages/Blockchains';
 import './Layout.scss';
 
 const drawerWidth = 240;
@@ -28,6 +30,8 @@ const Layout = () => {
           <Route path="/payments" element={<Payments />} />
           <Route path="/referrals" element={<Referrals />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/mnemonics" element={<Mnemonics />} />
+          <Route path="/blockchains" element={<Blockchains />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
         <Outlet />

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -22,6 +22,8 @@ const navItems = [
   { to: '/payments', label: 'Payments', icon: <PaymentIcon /> },
   { to: '/referrals', label: 'Referrals', icon: <ShareIcon /> },
   { to: '/settings', label: 'Settings', icon: <SettingsIcon /> },
+  { to: '/mnemonics', label: 'Mnemonics', icon: <DashboardIcon /> },
+  { to: '/blockchains', label: 'Blockchains', icon: <PaymentIcon /> },
 ];
 
 const Sidebar = () => (

--- a/src/pages/Blockchains.jsx
+++ b/src/pages/Blockchains.jsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Switch from '@mui/material/Switch';
+import Button from '@mui/material/Button';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import {
+  fetchBlockchainsRequest,
+  createBlockchainRequest,
+  updateBlockchainRequest,
+  deleteBlockchainRequest,
+} from '../redux/slices/blockchainsSlice';
+
+const Blockchains = () => {
+  const dispatch = useDispatch();
+  const { list } = useSelector(state => state.blockchains);
+  const loading = useSelector(state => state.ui.loading);
+  const [name, setName] = useState('');
+  const [walletSupported, setWalletSupported] = useState(false);
+  const [edit, setEdit] = useState(null);
+
+  useEffect(() => {
+    dispatch(fetchBlockchainsRequest());
+  }, [dispatch]);
+
+  const handleCreate = e => {
+    e.preventDefault();
+    dispatch(createBlockchainRequest({ name, wallet_generation_supported: walletSupported }));
+    setName('');
+    setWalletSupported(false);
+  };
+
+  const handleUpdate = () => {
+    if (!edit) return;
+    dispatch(updateBlockchainRequest({ id: edit.id, name: edit.name, wallet_generation_supported: edit.wallet_generation_supported }));
+    setEdit(null);
+  };
+
+  const startEdit = b => setEdit({ ...b });
+
+  return (
+    <>
+      <Typography variant="h4" gutterBottom>Blockchains</Typography>
+      <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
+        <TextField label="Name" value={name} onChange={e => setName(e.target.value)} size="small" sx={{ mr: 1 }} />
+        <Switch checked={walletSupported} onChange={e => setWalletSupported(e.target.checked)} />
+        <Button variant="contained" type="submit" disabled={loading}>Add</Button>
+      </form>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Wallet Generation</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {list.map(row => (
+              <TableRow key={row.id} hover>
+                <TableCell>{row.id}</TableCell>
+                <TableCell>{row.name}</TableCell>
+                <TableCell>{row.wallet_generation_supported ? 'Yes' : 'No'}</TableCell>
+                <TableCell>
+                  <Button size="small" onClick={() => startEdit(row)}>Edit</Button>
+                  <Button size="small" color="error" onClick={() => dispatch(deleteBlockchainRequest(row.id))}>Delete</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Dialog open={!!edit} onClose={() => setEdit(null)}>
+        <DialogTitle>Edit Blockchain</DialogTitle>
+        {edit && (
+          <>
+            <DialogContent>
+              <TextField
+                label="Name"
+                value={edit.name}
+                onChange={e => setEdit({ ...edit, name: e.target.value })}
+                fullWidth
+                sx={{ mb: 2 }}
+              />
+              <Switch
+                checked={edit.wallet_generation_supported}
+                onChange={e => setEdit({ ...edit, wallet_generation_supported: e.target.checked })}
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setEdit(null)}>Cancel</Button>
+              <Button onClick={handleUpdate} variant="contained" disabled={loading}>Save</Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </>
+  );
+};
+
+export default Blockchains;

--- a/src/pages/Mnemonics.jsx
+++ b/src/pages/Mnemonics.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import {
+  fetchMnemonicsRequest,
+  createMnemonicRequest,
+} from '../redux/slices/mnemonicsSlice';
+
+const Mnemonics = () => {
+  const dispatch = useDispatch();
+  const { list } = useSelector(state => state.mnemonics);
+  const loading = useSelector(state => state.ui.loading);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    dispatch(fetchMnemonicsRequest());
+  }, [dispatch]);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!name) return;
+    dispatch(createMnemonicRequest({ name }));
+    setName('');
+  };
+
+  return (
+    <>
+      <Typography variant="h4" gutterBottom>Mnemonics</Typography>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <TextField
+          label="Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          size="small"
+          sx={{ mr: 1 }}
+        />
+        <Button variant="contained" type="submit" disabled={loading}>Add</Button>
+      </form>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {list.map(row => (
+              <TableRow key={row.id} hover>
+                <TableCell>{row.id}</TableCell>
+                <TableCell>{row.name}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
+};
+
+export default Mnemonics;

--- a/src/redux/slices/blockchainsSlice.js
+++ b/src/redux/slices/blockchainsSlice.js
@@ -1,0 +1,47 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  list: [],
+  error: null,
+};
+
+const blockchainsSlice = createSlice({
+  name: 'blockchains',
+  initialState,
+  reducers: {
+    fetchBlockchainsRequest: () => {},
+    createBlockchainRequest: (_state, _action) => {},
+    updateBlockchainRequest: (_state, _action) => {},
+    deleteBlockchainRequest: (_state, _action) => {},
+    setBlockchains: (state, action) => {
+      state.list = action.payload;
+    },
+    addBlockchain: (state, action) => {
+      state.list.push(action.payload);
+    },
+    modifyBlockchain: (state, action) => {
+      const idx = state.list.findIndex(b => b.id === action.payload.id);
+      if (idx !== -1) state.list[idx] = action.payload;
+    },
+    removeBlockchain: (state, action) => {
+      state.list = state.list.filter(b => b.id !== action.payload);
+    },
+    setBlockchainsError: (state, action) => {
+      state.error = action.payload;
+    },
+  },
+});
+
+export const {
+  fetchBlockchainsRequest,
+  createBlockchainRequest,
+  updateBlockchainRequest,
+  deleteBlockchainRequest,
+  setBlockchains,
+  addBlockchain,
+  modifyBlockchain,
+  removeBlockchain,
+  setBlockchainsError,
+} = blockchainsSlice.actions;
+
+export default blockchainsSlice.reducer;

--- a/src/redux/slices/mnemonicsSlice.js
+++ b/src/redux/slices/mnemonicsSlice.js
@@ -1,0 +1,34 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  list: [],
+  error: null,
+};
+
+const mnemonicsSlice = createSlice({
+  name: 'mnemonics',
+  initialState,
+  reducers: {
+    fetchMnemonicsRequest: () => {},
+    createMnemonicRequest: (_state, _action) => {},
+    setMnemonics: (state, action) => {
+      state.list = action.payload;
+    },
+    addMnemonic: (state, action) => {
+      state.list.push(action.payload);
+    },
+    setMnemonicsError: (state, action) => {
+      state.error = action.payload;
+    },
+  },
+});
+
+export const {
+  fetchMnemonicsRequest,
+  createMnemonicRequest,
+  setMnemonics,
+  addMnemonic,
+  setMnemonicsError,
+} = mnemonicsSlice.actions;
+
+export default mnemonicsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -3,6 +3,8 @@ import createSagaMiddleware from 'redux-saga';
 import authReducer from './slices/authSlice';
 import uiReducer from './slices/uiSlice';
 import usersReducer from './slices/usersSlice';
+import mnemonicsReducer from './slices/mnemonicsSlice';
+import blockchainsReducer from './slices/blockchainsSlice';
 import rootSaga from '../sagas';
 
 const sagaMiddleware = createSagaMiddleware();
@@ -12,6 +14,8 @@ const store = configureStore({
     auth: authReducer,
     ui: uiReducer,
     users: usersReducer,
+    mnemonics: mnemonicsReducer,
+    blockchains: blockchainsReducer,
   },
   middleware: getDefaultMiddleware => getDefaultMiddleware({ thunk: false }).concat(sagaMiddleware),
 });

--- a/src/sagas/blockchainsSaga.js
+++ b/src/sagas/blockchainsSaga.js
@@ -1,0 +1,74 @@
+import { call, put, takeLatest } from 'redux-saga/effects';
+import {
+  getBlockchains,
+  createBlockchain,
+  updateBlockchain,
+  deleteBlockchain,
+} from '../services/blockchains';
+import {
+  fetchBlockchainsRequest,
+  createBlockchainRequest,
+  updateBlockchainRequest,
+  deleteBlockchainRequest,
+  setBlockchains,
+  addBlockchain,
+  modifyBlockchain,
+  removeBlockchain,
+  setBlockchainsError,
+} from '../redux/slices/blockchainsSlice';
+import { setLoading } from '../redux/slices/uiSlice';
+
+function* handleFetchBlockchains() {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(getBlockchains);
+    yield put(setBlockchains(data));
+  } catch (err) {
+    yield put(setBlockchainsError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleCreateBlockchain(action) {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(createBlockchain, action.payload);
+    yield put(addBlockchain(data));
+  } catch (err) {
+    yield put(setBlockchainsError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleUpdateBlockchain(action) {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(updateBlockchain, action.payload);
+    yield put(modifyBlockchain(data));
+  } catch (err) {
+    yield put(setBlockchainsError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleDeleteBlockchain(action) {
+  try {
+    yield put(setLoading(true));
+    yield call(deleteBlockchain, action.payload);
+    yield put(removeBlockchain(action.payload));
+  } catch (err) {
+    yield put(setBlockchainsError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+export default function* blockchainsSaga() {
+  yield takeLatest(fetchBlockchainsRequest.type, handleFetchBlockchains);
+  yield takeLatest(createBlockchainRequest.type, handleCreateBlockchain);
+  yield takeLatest(updateBlockchainRequest.type, handleUpdateBlockchain);
+  yield takeLatest(deleteBlockchainRequest.type, handleDeleteBlockchain);
+}

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,10 +1,14 @@
 import { all } from 'redux-saga/effects';
 import authSaga from './authSaga';
 import usersSaga from './usersSaga';
+import mnemonicsSaga from './mnemonicsSaga';
+import blockchainsSaga from './blockchainsSaga';
 
 export default function* rootSaga() {
   yield all([
     authSaga(),
     usersSaga(),
+    mnemonicsSaga(),
+    blockchainsSaga(),
   ]);
 }

--- a/src/sagas/mnemonicsSaga.js
+++ b/src/sagas/mnemonicsSaga.js
@@ -1,0 +1,39 @@
+import { call, put, takeLatest } from 'redux-saga/effects';
+import { getMnemonics, createMnemonic } from '../services/mnemonics';
+import {
+  fetchMnemonicsRequest,
+  createMnemonicRequest,
+  setMnemonics,
+  addMnemonic,
+  setMnemonicsError,
+} from '../redux/slices/mnemonicsSlice';
+import { setLoading } from '../redux/slices/uiSlice';
+
+function* handleFetchMnemonics() {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(getMnemonics);
+    yield put(setMnemonics(data));
+  } catch (err) {
+    yield put(setMnemonicsError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleCreateMnemonic(action) {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(createMnemonic, action.payload);
+    yield put(addMnemonic(data));
+  } catch (err) {
+    yield put(setMnemonicsError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+export default function* mnemonicsSaga() {
+  yield takeLatest(fetchMnemonicsRequest.type, handleFetchMnemonics);
+  yield takeLatest(createMnemonicRequest.type, handleCreateMnemonic);
+}

--- a/src/services/blockchains.js
+++ b/src/services/blockchains.js
@@ -1,0 +1,6 @@
+import api from './api';
+
+export const getBlockchains = () => api.get('/blockchains');
+export const createBlockchain = payload => api.post('/blockchains', payload);
+export const updateBlockchain = ({ id, ...rest }) => api.put(`/blockchains/${id}`, rest);
+export const deleteBlockchain = id => api.delete(`/blockchains/${id}`);

--- a/src/services/mnemonics.js
+++ b/src/services/mnemonics.js
@@ -1,0 +1,4 @@
+import api from './api';
+
+export const getMnemonics = () => api.get('/mnemonics');
+export const createMnemonic = payload => api.post('/mnemonics', payload);


### PR DESCRIPTION
## Summary
- implement mnemonics and blockchains slices and sagas
- add API services for new endpoints
- create Mnemonics and Blockchains pages with CRUD UIs
- wire new pages into layout and sidebar

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641b0aae58832b8525d48a53d6c35b