### PR TITLE
Add cryptocurrency management

### DIFF
--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -12,6 +12,7 @@ import Referrals from '../pages/Referrals';
 import Settings from '../pages/Settings';
 import Mnemonics from '../pages/Mnemonics';
 import Blockchains from '../pages/Blockchains';
+import Cryptocurrencies from '../pages/Cryptocurrencies';
 import './Layout.scss';
 
 const drawerWidth = 240;
@@ -32,6 +33,7 @@ const Layout = () => {
           <Route path="/settings" element={<Settings />} />
           <Route path="/mnemonics" element={<Mnemonics />} />
           <Route path="/blockchains" element={<Blockchains />} />
+          <Route path="/cryptocurrencies" element={<Cryptocurrencies />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
         <Outlet />

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -12,6 +12,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import PaymentIcon from '@mui/icons-material/Payment';
 import ShareIcon from '@mui/icons-material/Share';
 import SettingsIcon from '@mui/icons-material/Settings';
+import CurrencyBitcoinIcon from '@mui/icons-material/CurrencyBitcoin';
 import './Sidebar.scss';
 
 const drawerWidth = 240;
@@ -24,6 +25,7 @@ const navItems = [
   { to: '/settings', label: 'Settings', icon: <SettingsIcon /> },
   { to: '/mnemonics', label: 'Mnemonics', icon: <DashboardIcon /> },
   { to: '/blockchains', label: 'Blockchains', icon: <PaymentIcon /> },
+  { to: '/cryptocurrencies', label: 'Cryptocurrencies', icon: <CurrencyBitcoinIcon /> },
 ];
 
 const Sidebar = () => (

--- a/src/pages/Cryptocurrencies.jsx
+++ b/src/pages/Cryptocurrencies.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import {
+  fetchCryptocurrenciesRequest,
+  createCryptocurrencyRequest,
+  updateCryptocurrencyRequest,
+  deleteCryptocurrencyRequest,
+} from '../redux/slices/cryptocurrenciesSlice';
+
+const Cryptocurrencies = () => {
+  const dispatch = useDispatch();
+  const { list } = useSelector(state => state.cryptocurrencies);
+  const loading = useSelector(state => state.ui.loading);
+  const [name, setName] = useState('');
+  const [symbol, setSymbol] = useState('');
+  const [edit, setEdit] = useState(null);
+
+  useEffect(() => {
+    dispatch(fetchCryptocurrenciesRequest());
+  }, [dispatch]);
+
+  const handleCreate = e => {
+    e.preventDefault();
+    dispatch(createCryptocurrencyRequest({ name, symbol }));
+    setName('');
+    setSymbol('');
+  };
+
+  const handleUpdate = () => {
+    if (!edit) return;
+    dispatch(updateCryptocurrencyRequest({ id: edit.id, name: edit.name, symbol: edit.symbol }));
+    setEdit(null);
+  };
+
+  const startEdit = c => setEdit({ ...c });
+
+  return (
+    <>
+      <Typography variant="h4" gutterBottom>Cryptocurrencies</Typography>
+      <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
+        <TextField label="Name" value={name} onChange={e => setName(e.target.value)} size="small" sx={{ mr: 1 }} />
+        <TextField label="Symbol" value={symbol} onChange={e => setSymbol(e.target.value)} size="small" sx={{ mr: 1 }} />
+        <Button variant="contained" type="submit" disabled={loading}>Add</Button>
+      </form>
+      <TableContainer component={Paper}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Symbol</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {list.map(row => (
+              <TableRow key={row.id} hover>
+                <TableCell>{row.id}</TableCell>
+                <TableCell>{row.name}</TableCell>
+                <TableCell>{row.symbol}</TableCell>
+                <TableCell>
+                  <Button size="small" onClick={() => startEdit(row)}>Edit</Button>
+                  <Button size="small" color="error" onClick={() => dispatch(deleteCryptocurrencyRequest(row.id))}>Delete</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Dialog open={!!edit} onClose={() => setEdit(null)}>
+        <DialogTitle>Edit Cryptocurrency</DialogTitle>
+        {edit && (
+          <>
+            <DialogContent>
+              <TextField
+                label="Name"
+                value={edit.name}
+                onChange={e => setEdit({ ...edit, name: e.target.value })}
+                fullWidth
+                sx={{ mb: 2 }}
+              />
+              <TextField
+                label="Symbol"
+                value={edit.symbol}
+                onChange={e => setEdit({ ...edit, symbol: e.target.value })}
+                fullWidth
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setEdit(null)}>Cancel</Button>
+              <Button onClick={handleUpdate} variant="contained" disabled={loading}>Save</Button>
+            </DialogActions>
+          </>
+        )}
+      </Dialog>
+    </>
+  );
+};
+
+export default Cryptocurrencies;

--- a/src/redux/slices/cryptocurrenciesSlice.js
+++ b/src/redux/slices/cryptocurrenciesSlice.js
@@ -1,0 +1,47 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  list: [],
+  error: null,
+};
+
+const cryptocurrenciesSlice = createSlice({
+  name: 'cryptocurrencies',
+  initialState,
+  reducers: {
+    fetchCryptocurrenciesRequest: () => {},
+    createCryptocurrencyRequest: (_state, _action) => {},
+    updateCryptocurrencyRequest: (_state, _action) => {},
+    deleteCryptocurrencyRequest: (_state, _action) => {},
+    setCryptocurrencies: (state, action) => {
+      state.list = action.payload;
+    },
+    addCryptocurrency: (state, action) => {
+      state.list.push(action.payload);
+    },
+    modifyCryptocurrency: (state, action) => {
+      const idx = state.list.findIndex(c => c.id === action.payload.id);
+      if (idx !== -1) state.list[idx] = action.payload;
+    },
+    removeCryptocurrency: (state, action) => {
+      state.list = state.list.filter(c => c.id !== action.payload);
+    },
+    setCryptocurrenciesError: (state, action) => {
+      state.error = action.payload;
+    },
+  },
+});
+
+export const {
+  fetchCryptocurrenciesRequest,
+  createCryptocurrencyRequest,
+  updateCryptocurrencyRequest,
+  deleteCryptocurrencyRequest,
+  setCryptocurrencies,
+  addCryptocurrency,
+  modifyCryptocurrency,
+  removeCryptocurrency,
+  setCryptocurrenciesError,
+} = cryptocurrenciesSlice.actions;
+
+export default cryptocurrenciesSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -5,6 +5,7 @@ import uiReducer from './slices/uiSlice';
 import usersReducer from './slices/usersSlice';
 import mnemonicsReducer from './slices/mnemonicsSlice';
 import blockchainsReducer from './slices/blockchainsSlice';
+import cryptocurrenciesReducer from './slices/cryptocurrenciesSlice';
 import rootSaga from '../sagas';
 
 const sagaMiddleware = createSagaMiddleware();
@@ -16,6 +17,7 @@ const store = configureStore({
     users: usersReducer,
     mnemonics: mnemonicsReducer,
     blockchains: blockchainsReducer,
+    cryptocurrencies: cryptocurrenciesReducer,
   },
   middleware: getDefaultMiddleware => getDefaultMiddleware({ thunk: false }).concat(sagaMiddleware),
 });

--- a/src/sagas/cryptocurrenciesSaga.js
+++ b/src/sagas/cryptocurrenciesSaga.js
@@ -1,0 +1,74 @@
+import { call, put, takeLatest } from 'redux-saga/effects';
+import {
+  getCryptocurrencies,
+  createCryptocurrency,
+  updateCryptocurrency,
+  deleteCryptocurrency,
+} from '../services/cryptocurrencies';
+import {
+  fetchCryptocurrenciesRequest,
+  createCryptocurrencyRequest,
+  updateCryptocurrencyRequest,
+  deleteCryptocurrencyRequest,
+  setCryptocurrencies,
+  addCryptocurrency,
+  modifyCryptocurrency,
+  removeCryptocurrency,
+  setCryptocurrenciesError,
+} from '../redux/slices/cryptocurrenciesSlice';
+import { setLoading } from '../redux/slices/uiSlice';
+
+function* handleFetchCryptocurrencies() {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(getCryptocurrencies);
+    yield put(setCryptocurrencies(data));
+  } catch (err) {
+    yield put(setCryptocurrenciesError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleCreateCryptocurrency(action) {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(createCryptocurrency, action.payload);
+    yield put(addCryptocurrency(data));
+  } catch (err) {
+    yield put(setCryptocurrenciesError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleUpdateCryptocurrency(action) {
+  try {
+    yield put(setLoading(true));
+    const { data } = yield call(updateCryptocurrency, action.payload);
+    yield put(modifyCryptocurrency(data));
+  } catch (err) {
+    yield put(setCryptocurrenciesError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+function* handleDeleteCryptocurrency(action) {
+  try {
+    yield put(setLoading(true));
+    yield call(deleteCryptocurrency, action.payload);
+    yield put(removeCryptocurrency(action.payload));
+  } catch (err) {
+    yield put(setCryptocurrenciesError(err.message));
+  } finally {
+    yield put(setLoading(false));
+  }
+}
+
+export default function* cryptocurrenciesSaga() {
+  yield takeLatest(fetchCryptocurrenciesRequest.type, handleFetchCryptocurrencies);
+  yield takeLatest(createCryptocurrencyRequest.type, handleCreateCryptocurrency);
+  yield takeLatest(updateCryptocurrencyRequest.type, handleUpdateCryptocurrency);
+  yield takeLatest(deleteCryptocurrencyRequest.type, handleDeleteCryptocurrency);
+}

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -3,6 +3,7 @@ import authSaga from './authSaga';
 import usersSaga from './usersSaga';
 import mnemonicsSaga from './mnemonicsSaga';
 import blockchainsSaga from './blockchainsSaga';
+import cryptocurrenciesSaga from './cryptocurrenciesSaga';
 
 export default function* rootSaga() {
   yield all([
@@ -10,5 +11,6 @@ export default function* rootSaga() {
     usersSaga(),
     mnemonicsSaga(),
     blockchainsSaga(),
+    cryptocurrenciesSaga(),
   ]);
 }

--- a/src/services/cryptocurrencies.js
+++ b/src/services/cryptocurrencies.js
@@ -1,0 +1,6 @@
+import api from './api';
+
+export const getCryptocurrencies = () => api.get('/cryptocurrencies');
+export const createCryptocurrency = payload => api.post('/cryptocurrencies', payload);
+export const updateCryptocurrency = ({ id, ...rest }) => api.put(`/cryptocurrencies/${id}`, rest);
+export const deleteCryptocurrency = id => api.delete(`/cryptocurrencies/${id}`);


### PR DESCRIPTION
## Summary
- add cryptocurrencies CRUD page and navigation item
- create cryptocurrency redux slice and saga
- call API service for cryptocurrencies
- register saga and reducer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686434e7f0ac832b969fe8c897389dbf