### PR TITLE
Add modal components for creating records

### DIFF
--- a/src/components/modals/AddBlockchainModal.jsx
+++ b/src/components/modals/AddBlockchainModal.jsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Snackbar from '@mui/material/Snackbar';
+import { createBlockchainRequest } from '../../redux/slices/blockchainsSlice';
+
+const AddBlockchainModal = ({ open, onClose }) => {
+  const dispatch = useDispatch();
+  const loading = useSelector(state => state.ui.loading);
+
+  const [name, setName] = useState('');
+  const [symbol, setSymbol] = useState('');
+  const [walletSupported, setWalletSupported] = useState(false);
+  const [showErrors, setShowErrors] = useState(false);
+  const [snackOpen, setSnackOpen] = useState(false);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!name.trim() || !symbol.trim()) {
+      setShowErrors(true);
+      return;
+    }
+    dispatch(
+      createBlockchainRequest({
+        name,
+        symbol,
+        wallet_generation_supported: walletSupported,
+      }),
+    );
+    onClose();
+    setSnackOpen(true);
+    setName('');
+    setSymbol('');
+    setWalletSupported(false);
+    setShowErrors(false);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>Add Blockchain</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Name"
+            fullWidth
+            value={name}
+            onChange={e => setName(e.target.value)}
+            error={showErrors && !name.trim()}
+            helperText={showErrors && !name.trim() ? 'Name is required' : ''}
+          />
+          <TextField
+            margin="dense"
+            label="Symbol"
+            fullWidth
+            value={symbol}
+            onChange={e => setSymbol(e.target.value)}
+            error={showErrors && !symbol.trim()}
+            helperText={showErrors && !symbol.trim() ? 'Symbol is required' : ''}
+          />
+          <Select
+            value={walletSupported}
+            onChange={e => setWalletSupported(e.target.value === 'true')}
+            fullWidth
+            margin="dense"
+          >
+            <MenuItem value={false}>Wallet Generation Disabled</MenuItem>
+            <MenuItem value={true}>Wallet Generation Enabled</MenuItem>
+          </Select>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSubmit} variant="contained" disabled={loading}>
+            Add
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackOpen(false)}
+        message="Blockchain created"
+      />
+    </>
+  );
+};
+
+export default AddBlockchainModal;

--- a/src/components/modals/AddCryptoModal.jsx
+++ b/src/components/modals/AddCryptoModal.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
+import { createCryptocurrencyRequest } from '../../redux/slices/cryptocurrenciesSlice';
+
+const AddCryptoModal = ({ open, onClose }) => {
+  const dispatch = useDispatch();
+  const loading = useSelector(state => state.ui.loading);
+
+  const [name, setName] = useState('');
+  const [symbol, setSymbol] = useState('');
+  const [showErrors, setShowErrors] = useState(false);
+  const [snackOpen, setSnackOpen] = useState(false);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!name.trim() || !symbol.trim()) {
+      setShowErrors(true);
+      return;
+    }
+    dispatch(createCryptocurrencyRequest({ name, symbol }));
+    onClose();
+    setSnackOpen(true);
+    setName('');
+    setSymbol('');
+    setShowErrors(false);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>Add Cryptocurrency</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Name"
+            fullWidth
+            value={name}
+            onChange={e => setName(e.target.value)}
+            error={showErrors && !name.trim()}
+            helperText={showErrors && !name.trim() ? 'Name is required' : ''}
+          />
+          <TextField
+            margin="dense"
+            label="Symbol"
+            fullWidth
+            value={symbol}
+            onChange={e => setSymbol(e.target.value)}
+            error={showErrors && !symbol.trim()}
+            helperText={showErrors && !symbol.trim() ? 'Symbol is required' : ''}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSubmit} variant="contained" disabled={loading}>
+            Add
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackOpen(false)}
+        message="Cryptocurrency created"
+      />
+    </>
+  );
+};
+
+export default AddCryptoModal;

--- a/src/components/modals/AddMnemonicModal.jsx
+++ b/src/components/modals/AddMnemonicModal.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Snackbar from '@mui/material/Snackbar';
+import { createMnemonicRequest } from '../../redux/slices/mnemonicsSlice';
+
+const AddMnemonicModal = ({ open, onClose }) => {
+  const dispatch = useDispatch();
+  const loading = useSelector(state => state.ui.loading);
+
+  const [name, setName] = useState('');
+  const [showError, setShowError] = useState(false);
+  const [snackOpen, setSnackOpen] = useState(false);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setShowError(true);
+      return;
+    }
+    dispatch(createMnemonicRequest({ name }));
+    onClose();
+    setSnackOpen(true);
+    setName('');
+    setShowError(false);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>Add Mnemonic</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            label="Name"
+            fullWidth
+            value={name}
+            onChange={e => setName(e.target.value)}
+            error={showError && !name.trim()}
+            helperText={showError && !name.trim() ? 'Name is required' : ''}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSubmit} variant="contained" disabled={loading}>
+            Add
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Snackbar
+        open={snackOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackOpen(false)}
+        message="Mnemonic created"
+      />
+    </>
+  );
+};
+
+export default AddMnemonicModal;

--- a/src/pages/Blockchains.jsx
+++ b/src/pages/Blockchains.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
 import Switch from '@mui/material/Switch';
 import Button from '@mui/material/Button';
 import Table from '@mui/material/Table';
@@ -15,9 +14,9 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
+import AddBlockchainModal from '../components/modals/AddBlockchainModal';
 import {
   fetchBlockchainsRequest,
-  createBlockchainRequest,
   updateBlockchainRequest,
   deleteBlockchainRequest,
 } from '../redux/slices/blockchainsSlice';
@@ -26,20 +25,15 @@ const Blockchains = () => {
   const dispatch = useDispatch();
   const { list } = useSelector(state => state.blockchains);
   const loading = useSelector(state => state.ui.loading);
-  const [name, setName] = useState('');
-  const [walletSupported, setWalletSupported] = useState(false);
+  const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState(null);
 
   useEffect(() => {
     dispatch(fetchBlockchainsRequest());
   }, [dispatch]);
 
-  const handleCreate = e => {
-    e.preventDefault();
-    dispatch(createBlockchainRequest({ name, wallet_generation_supported: walletSupported }));
-    setName('');
-    setWalletSupported(false);
-  };
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
 
   const handleUpdate = () => {
     if (!edit) return;
@@ -52,11 +46,9 @@ const Blockchains = () => {
   return (
     <>
       <Typography variant="h4" gutterBottom>Blockchains</Typography>
-      <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
-        <TextField label="Name" value={name} onChange={e => setName(e.target.value)} size="small" sx={{ mr: 1 }} />
-        <Switch checked={walletSupported} onChange={e => setWalletSupported(e.target.checked)} />
-        <Button variant="contained" type="submit" disabled={loading}>Add</Button>
-      </form>
+      <Button variant="contained" onClick={handleOpen} sx={{ mb: 2 }} disabled={loading}>
+        Add
+      </Button>
       <TableContainer component={Paper}>
         <Table size="small">
           <TableHead>
@@ -82,6 +74,8 @@ const Blockchains = () => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <AddBlockchainModal open={open} onClose={handleClose} />
 
       <Dialog open={!!edit} onClose={() => setEdit(null)}>
         <DialogTitle>Edit Blockchain</DialogTitle>

--- a/src/pages/Cryptocurrencies.jsx
+++ b/src/pages/Cryptocurrencies.jsx
@@ -14,9 +14,9 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
+import AddCryptoModal from '../components/modals/AddCryptoModal';
 import {
   fetchCryptocurrenciesRequest,
-  createCryptocurrencyRequest,
   updateCryptocurrencyRequest,
   deleteCryptocurrencyRequest,
 } from '../redux/slices/cryptocurrenciesSlice';
@@ -25,20 +25,15 @@ const Cryptocurrencies = () => {
   const dispatch = useDispatch();
   const { list } = useSelector(state => state.cryptocurrencies);
   const loading = useSelector(state => state.ui.loading);
-  const [name, setName] = useState('');
-  const [symbol, setSymbol] = useState('');
+  const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState(null);
 
   useEffect(() => {
     dispatch(fetchCryptocurrenciesRequest());
   }, [dispatch]);
 
-  const handleCreate = e => {
-    e.preventDefault();
-    dispatch(createCryptocurrencyRequest({ name, symbol }));
-    setName('');
-    setSymbol('');
-  };
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
 
   const handleUpdate = () => {
     if (!edit) return;
@@ -51,11 +46,9 @@ const Cryptocurrencies = () => {
   return (
     <>
       <Typography variant="h4" gutterBottom>Cryptocurrencies</Typography>
-      <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
-        <TextField label="Name" value={name} onChange={e => setName(e.target.value)} size="small" sx={{ mr: 1 }} />
-        <TextField label="Symbol" value={symbol} onChange={e => setSymbol(e.target.value)} size="small" sx={{ mr: 1 }} />
-        <Button variant="contained" type="submit" disabled={loading}>Add</Button>
-      </form>
+      <Button variant="contained" onClick={handleOpen} sx={{ mb: 2 }} disabled={loading}>
+        Add
+      </Button>
       <TableContainer component={Paper}>
         <Table size="small">
           <TableHead>
@@ -81,6 +74,8 @@ const Cryptocurrencies = () => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <AddCryptoModal open={open} onClose={handleClose} />
 
       <Dialog open={!!edit} onClose={() => setEdit(null)}>
         <DialogTitle>Edit Cryptocurrency</DialogTitle>

--- a/src/pages/Mnemonics.jsx
+++ b/src/pages/Mnemonics.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -10,41 +9,30 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import AddMnemonicModal from '../components/modals/AddMnemonicModal';
 import {
   fetchMnemonicsRequest,
-  createMnemonicRequest,
 } from '../redux/slices/mnemonicsSlice';
 
 const Mnemonics = () => {
   const dispatch = useDispatch();
   const { list } = useSelector(state => state.mnemonics);
   const loading = useSelector(state => state.ui.loading);
-  const [name, setName] = useState('');
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     dispatch(fetchMnemonicsRequest());
   }, [dispatch]);
 
-  const handleSubmit = e => {
-    e.preventDefault();
-    if (!name) return;
-    dispatch(createMnemonicRequest({ name }));
-    setName('');
-  };
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
 
   return (
     <>
       <Typography variant="h4" gutterBottom>Mnemonics</Typography>
-      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
-        <TextField
-          label="Name"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          size="small"
-          sx={{ mr: 1 }}
-        />
-        <Button variant="contained" type="submit" disabled={loading}>Add</Button>
-      </form>
+      <Button variant="contained" onClick={handleOpen} sx={{ mb: 2 }} disabled={loading}>
+        Add
+      </Button>
       <TableContainer component={Paper}>
         <Table size="small">
           <TableHead>
@@ -63,6 +51,7 @@ const Mnemonics = () => {
           </TableBody>
         </Table>
       </TableContainer>
+      <AddMnemonicModal open={open} onClose={handleClose} />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- create Material UI modals for adding mnemonics, blockchains and cryptocurrencies
- use new modals from the respective pages
- replace inline add forms with Add buttons that open the modals

## Testing
- `npm test --silent -- -w=off` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643837b40c832ba70289ae3a59ca4e