### PR TITLE
Update API configuration

### DIFF
--- a/src/pages/Blockchains.jsx
+++ b/src/pages/Blockchains.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Typography from '@mui/material/Typography';
 import Switch from '@mui/material/Switch';
 import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -46,6 +47,7 @@ const Blockchains = () => {
   return (
     <>
       <Typography variant="h4" gutterBottom>Blockchains</Typography>
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
       <Button variant="contained" onClick={handleOpen} sx={{ mb: 2 }} disabled={loading}>
         Add
       </Button>

--- a/src/pages/Cryptocurrencies.jsx
+++ b/src/pages/Cryptocurrencies.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -46,6 +47,7 @@ const Cryptocurrencies = () => {
   return (
     <>
       <Typography variant="h4" gutterBottom>Cryptocurrencies</Typography>
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
       <Button variant="contained" onClick={handleOpen} sx={{ mb: 2 }} disabled={loading}>
         Add
       </Button>

--- a/src/pages/Mnemonics.jsx
+++ b/src/pages/Mnemonics.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import LinearProgress from '@mui/material/LinearProgress';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -30,6 +31,7 @@ const Mnemonics = () => {
   return (
     <>
       <Typography variant="h4" gutterBottom>Mnemonics</Typography>
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
       <Button variant="contained" onClick={handleOpen} sx={{ mb: 2 }} disabled={loading}>
         Add
       </Button>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL,
+  baseURL: process.env.REACT_APP_API_URL || 'http://34.165.103.177:3000',
 });
 
 export default api;

--- a/src/services/cryptocurrencies.js
+++ b/src/services/cryptocurrencies.js
@@ -1,6 +1,6 @@
 import api from './api';
 
-export const getCryptocurrencies = () => api.get('/cryptocurrencies');
-export const createCryptocurrency = payload => api.post('/cryptocurrencies', payload);
-export const updateCryptocurrency = ({ id, ...rest }) => api.put(`/cryptocurrencies/${id}`, rest);
-export const deleteCryptocurrency = id => api.delete(`/cryptocurrencies/${id}`);
+export const getCryptocurrencies = () => api.get('/cryptos');
+export const createCryptocurrency = payload => api.post('/cryptos', payload);
+export const updateCryptocurrency = ({ id, ...rest }) => api.put(`/cryptos/${id}`, rest);
+export const deleteCryptocurrency = id => api.delete(`/cryptos/${id}`);


### PR DESCRIPTION
## Summary
- default `axios` base URL to `http://34.165.103.177:3000`
- switch cryptocurrency service endpoints to `/cryptos`
- show a loading bar when blockchains, cryptocurrencies, and mnemonics data load

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643ad15234832bb2883006fbe76712